### PR TITLE
added patch for IE11.

### DIFF
--- a/jawr-core/pom.xml
+++ b/jawr-core/pom.xml
@@ -49,6 +49,7 @@
 	</scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
 	<build>
 		<plugins>

--- a/jawr-core/src/main/java/net/jawr/web/resource/bundle/variant/resolver/BrowserResolver.java
+++ b/jawr-core/src/main/java/net/jawr/web/resource/bundle/variant/resolver/BrowserResolver.java
@@ -31,6 +31,7 @@ import net.jawr.web.resource.bundle.variant.VariantSet;
 public class BrowserResolver implements VariantResolver {
 
 	private static Pattern IE_PATTERN = Pattern.compile("MSIE (\\d+)");
+	public static String USER_AGENT_HEADER = "User-Agent";
 	
 	/* (non-Javadoc)
 	 * @see net.jawr.web.resource.bundle.variant.VariantResolver#getVariantType()
@@ -57,8 +58,8 @@ public class BrowserResolver implements VariantResolver {
 	 */
 	public String resolveVariant(HttpServletRequest request) {
 		
-		String browser = null;
-		String userAgent = request.getHeader("User-Agent");
+		String browser = "other";
+		String userAgent = request.getHeader(USER_AGENT_HEADER);
 		if(userAgent != null){
 			Matcher matcher = IE_PATTERN.matcher(userAgent);
 			if(matcher.find()){

--- a/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/variant/resolver/BrowserVariantResolverTestCase.java
+++ b/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/variant/resolver/BrowserVariantResolverTestCase.java
@@ -3,53 +3,106 @@
  */
 package test.net.jawr.web.resource.bundle.variant.resolver;
 
-import static org.mockito.Mockito.when;
 
 import javax.servlet.http.HttpServletRequest;
 
 import junit.framework.TestCase;
 import net.jawr.web.resource.bundle.variant.resolver.BrowserResolver;
-
-import org.mockito.Mockito;
+import static org.mockito.BDDMockito.*;
+import org.mockito.*;
+import static net.jawr.web.resource.bundle.variant.resolver.BrowserResolver.*;
 
 /**
  * @author ibrahim
- *
  */
 public class BrowserVariantResolverTestCase extends TestCase {
 
-	BrowserResolver resolver = new BrowserResolver();
-	
-	public void testResolveVariant(){
-		
-		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-		when(request.getHeader("User-Agent")).thenReturn("Firefox 6");
-	    String variant = resolver.resolveVariant(request);
-		assertEquals("firefox", variant);
-		
-		when(request.getHeader("User-Agent")).thenReturn("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)");
-	    variant = resolver.resolveVariant(request); 
-		assertEquals("ie6", variant);
-		
-		when(request.getHeader("User-Agent")).thenReturn("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.0)");
-	    variant = resolver.resolveVariant(request); 
-		assertEquals("ie7", variant);
-		
-		when(request.getHeader("User-Agent")).thenReturn("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.A.B.C Safari/525.13");
-	    variant = resolver.resolveVariant(request); 
-		assertEquals("webkit", variant);
+	private BrowserResolver resolver;
 
-		when(request.getHeader("User-Agent")).thenReturn("Opera/9.25 (X11; Linux i686; U; fr-ca)");
-	    variant = resolver.resolveVariant(request); 
-		assertEquals("opera", variant);
-		
-		when(request.getHeader("User-Agent")).thenReturn(null);
-	    variant = resolver.resolveVariant(request);
-		assertNull(variant);
-		
-		when(request.getHeader("User-Agent")).thenReturn("Googlebot/2.X (http://www.googlebot.com/bot.html)");
-	    variant = resolver.resolveVariant(request);
-		assertNull(variant);
+	@Mock
+	private HttpServletRequest request;
+
+	public void setUp(){
+		resolver = new BrowserResolver();
+		MockitoAnnotations.initMocks(this);
 	}
-	
+
+	public void testResolveVariantForFirefox(){
+		when(request.getHeader(USER_AGENT_HEADER)).thenReturn("Firefox 6");
+		String variant = resolver.resolveVariant(request);
+		assertEquals("firefox", variant);
+	}
+
+	public void testResolveVariantForIE6(){
+		when(request.getHeader(USER_AGENT_HEADER)).thenReturn("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)");
+		String variant = resolver.resolveVariant(request);
+		assertEquals("ie6", variant);
+	}
+
+	public void testResolveVariantForIE7(){
+		when(request.getHeader(USER_AGENT_HEADER)).thenReturn("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.0)");
+		String variant = resolver.resolveVariant(request);
+		assertEquals("ie7", variant);
+	}
+
+	public void testResolveVariantForIE8(){
+		when(request.getHeader(USER_AGENT_HEADER)).thenReturn("Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)");
+		String variant = resolver.resolveVariant(request);
+		assertEquals("ie8", variant);
+	}
+
+	public void testResolveVariantForIE9(){
+		when(request.getHeader(USER_AGENT_HEADER)).thenReturn("Mozilla/5.0 (Windows; U; MSIE 9.0; Windows NT 9.0; en-US)");
+		String variant = resolver.resolveVariant(request);
+		assertEquals("ie9", variant);
+	}
+
+	public void testResolveVariantForIE10(){
+		when(request.getHeader(USER_AGENT_HEADER)).thenReturn("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)");
+		String variant = resolver.resolveVariant(request);
+		assertEquals("ie10", variant);
+	}
+
+	public void testResolveVariantForIE11(){
+		when(request.getHeader(USER_AGENT_HEADER)).thenReturn("Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko");
+		String variant = resolver.resolveVariant(request);
+		assertEquals("other", variant);
+	}
+
+	public void testResolveVariantForWebkit(){
+		when(request.getHeader(USER_AGENT_HEADER)).thenReturn("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.A.B.C Safari/525.13\"");
+		String variant = resolver.resolveVariant(request);
+		assertEquals("webkit", variant);
+	}
+
+	public void testResolveVariantForOpera(){
+		when(request.getHeader(USER_AGENT_HEADER)).thenReturn("Opera/9.25 (X11; Linux i686; U; fr-ca)");
+		String variant = resolver.resolveVariant(request);
+		assertEquals("opera", variant);
+	}
+
+	public void testResolveVariantForGoogleBot(){
+		when(request.getHeader(USER_AGENT_HEADER)).thenReturn("Googlebot/2.X (http://www.googlebot.com/bot.html)");
+		String variant = resolver.resolveVariant(request);
+		assertEquals("other", variant);
+	}
+
+	public void testResolveVariantForUnknownOrFutureBrowsers(){
+		when(request.getHeader(USER_AGENT_HEADER)).thenReturn("Foo");
+		String variant = resolver.resolveVariant(request);
+		assertEquals("other", variant);
+	}
+
+	public void testForEmptyUserAgent(){
+		when(request.getHeader(USER_AGENT_HEADER)).thenReturn("");
+		String variant = resolver.resolveVariant(request);
+		assertEquals("other", variant);
+	}
+
+	public void testForBotsAndNPEs(){
+		when(request.getHeader(USER_AGENT_HEADER)).thenReturn(null);
+		String variant = resolver.resolveVariant(request);
+		assertEquals("other", variant);
+	}
 }
+


### PR DESCRIPTION
Patched BrowserResolver to never return a null reference for unknown browsers ( including IE11 ).  Also broke down the unit test into smaller chunks, and changed the unit test to no longer expect null references.  In the pom I also changed the report encoding to explicitly be UTF-8.

This branch may also need some changes to RendererRequestUtils, @see:
<code>private static Pattern IE_USER_AGENT_PATTERN = Pattern.compile("MSIE (d+)");</code>

If there's a formatter that I can use to clean up special characters, please send it to me ( timjvollmer@gmail.com ) for [tabs/spaces, line endings, braces, ...]
