### PR TITLE
Fix duplicated bundle resource processing

### DIFF
--- a/jawr-core/src/main/java/net/jawr/web/resource/bundle/handler/ResourceBundlesHandlerImpl.java
+++ b/jawr-core/src/main/java/net/jawr/web/resource/bundle/handler/ResourceBundlesHandlerImpl.java
@@ -860,10 +860,12 @@ public class ResourceBundlesHandlerImpl implements ResourceBundlesHandler {
 					resourceHandler, config);
 			JoinableResourceBundleContent store = null;
 
-			// Process the bundle
+			// Process the bundle for searching variants
 			status.setSearchingPostProcessorVariants(true);
 			joinAndPostProcessBundle(bundle, status, processBundle);
 
+			// Process the bundle variants
+			status.setSearchingPostProcessorVariants(false);
 			Map<String, VariantSet> postProcessVariants = status
 					.getPostProcessVariants();
 			if (!postProcessVariants.isEmpty()) {
@@ -875,7 +877,6 @@ public class ResourceBundlesHandlerImpl implements ResourceBundlesHandler {
 						.concatVariants(bundle.getVariants(),
 								postProcessVariants);
 				bundle.setVariants(newVariants);
-				status.setSearchingPostProcessorVariants(false);
 				joinAndPostProcessBundle(bundle, status, processBundle);
 			}
 


### PR DESCRIPTION
In my project i have heavy processing of less files (30 seconds to process). I noticed that the processing of the bundle are done twice. This fix allow to have only one processing and for my case to divide almost by 2 the processing time.
